### PR TITLE
fix: harden destructive version-retention logic and config guards

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,24 @@
             <version>3.4.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.25.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/jahia/community/versionscleaner/CleanCommand.java
+++ b/src/main/java/org/jahia/community/versionscleaner/CleanCommand.java
@@ -74,6 +74,11 @@ public class CleanCommand implements Action {
     private static final String PAUSE_DURATION_MARKER = "versions-cleaner.pause.duration";
     private static final String STARTUP_DELAY_MARKER = "versions-cleaner.startup.delay";
     private static final String FAILED_TO_REMOVE = "Failed to remove ";
+    // The version storage of a node always contains an implicit jcr:rootVersion that must never be deleted.
+    // Retention math is expressed in terms of deletable (non-root) versions, so the desired count is offset by it.
+    private static final int ROOT_VERSION_COUNT = 1;
+    // Default truncation length applied to version names before logging, to avoid flooding logs with huge names.
+    private static final int MAX_PRINTABLE_NAME_LENGTH = 2000;
 
     @Option(name = "-r", aliases = "--reindex-default-workspace", description = "Reindex default workspace before cleaning")
     private Boolean reindexDefaultWorkspace = Boolean.FALSE;
@@ -365,7 +370,8 @@ public class CleanCommand implements Action {
     }
 
     private static void keepLastNVersions(VersionHistory vh, CleanerContext context) {
-        if (context.getNbVersionsToKeep() < 0) return;
+        final long nbVersionsToKeep = context.getNbVersionsToKeep();
+        if (nbVersionsToKeep < 0) return;
 
         String path;
         try {
@@ -379,17 +385,35 @@ public class CleanCommand implements Action {
             final RangeIterator versionIterator = getVersionsIterator(vh, context);
             final long nbVersions = getVersionsCount(vh, versionIterator, context);
             logger.debug("{} has {} versions", path, nbVersions);
-            // Do clean if we have more versions than the desired number + 1 for the root version
-            if (nbVersions > context.getNbVersionsToKeep() + 1) {
+            // Do clean only if we have more versions than the desired number + the implicit root version.
+            if (nbVersions > nbVersionsToKeep + ROOT_VERSION_COUNT) {
                 final List<String> versionNames = getNonRootVersionNames(versionIterator, context);
-                final int nbToKeep = (int) context.getNbVersionsToKeep();
-                versionNames.subList(versionNames.size() - nbToKeep, versionNames.size()).clear();
+                retainNewestVersions(versionNames, nbVersionsToKeep);
                 final long deletedVersions = deleteVersionNodes(vh, versionNames, context);
                 context.trackDeletedVersions(deletedVersions, false);
             }
         } catch (Exception ex) {
-            logger.info("Exception when trying to clean a version history", ex);
+            // Isolate the failure to this version history: log with context (this is a destructive
+            // operation) and let the scan continue with the remaining histories rather than aborting.
+            logger.error("Failed to reduce version history {}", path, ex);
         }
+    }
+
+    /**
+     * Trims {@code versionNames} (ordered oldest-first, root already excluded) so that only the
+     * {@code nbVersionsToKeep} newest entries are removed from the deletion candidate list, leaving the
+     * oldest ones to be deleted. The cut point is clamped defensively: counting differences between
+     * the version-storage iterator and the materialised candidate list must never produce a negative
+     * index or attempt to keep more versions than exist.
+     */
+    static void retainNewestVersions(List<String> versionNames, long nbVersionsToKeep) {
+        final int size = versionNames.size();
+        // nbVersionsToKeep is bounded by the number of versions ever created for a node, so it fits an int;
+        // clamp anyway to stay safe against pathological/overflowing configuration values.
+        final int nbToKeep = (int) Math.min(nbVersionsToKeep, size);
+        final int fromIndex = Math.max(0, size - nbToKeep);
+        if (fromIndex >= size) return;
+        versionNames.subList(fromIndex, size).clear();
     }
 
     private static long deleteVersionNodes(VersionHistory vh, List<String> names, CleanerContext context) {
@@ -689,18 +713,26 @@ public class CleanCommand implements Action {
         if (StringUtils.isBlank(relativePath) || "/".equals(relativePath)) {
             return parent;
         }
+        return parent.getNode(normalizeSubtreePath(relativePath));
+    }
+
+    /**
+     * Normalises a configured subtree path to a relative path under the version storage root and rejects any
+     * parent ({@code ..}) or self ({@code .}) segment, so the destructive scan can never escape
+     * {@code /jcr:system/jcr:versionStorage}. Returns the relative path (leading slash stripped).
+     */
+    static String normalizeSubtreePath(String relativePath) {
         final String normalized = relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
-        // Reject parent-directory traversal segments so the cleanup scope cannot escape /jcr:system/jcr:versionStorage
         for (String segment : normalized.split("/")) {
             if ("..".equals(segment) || ".".equals(segment)) {
                 throw new IllegalArgumentException("Invalid subtree path: parent or self segments are not allowed");
             }
         }
-        return parent.getNode(normalized);
+        return normalized;
     }
 
     private static String toPrintableName(String versionName) {
-        return toPrintableName(versionName, 2000);
+        return toPrintableName(versionName, MAX_PRINTABLE_NAME_LENGTH);
     }
 
     private static String toPrintableName(String versionName, int maxLength) {

--- a/src/main/java/org/jahia/community/versionscleaner/CleanerContext.java
+++ b/src/main/java/org/jahia/community/versionscleaner/CleanerContext.java
@@ -22,6 +22,13 @@ public class CleanerContext {
 
     private static final Logger logger = LoggerFactory.getLogger(CleanerContext.class);
 
+    // Default number of processed version histories between forced JCR session refreshes. Refreshing
+    // periodically keeps the session caches from growing unbounded during a long destructive scan.
+    static final long DEFAULT_SESSION_REFRESH_INTERVAL = 100L;
+    // Default threshold (in versions) above which an orphaned history is purged version-by-version to
+    // keep the memory footprint bounded instead of materialising the whole history at once.
+    static final long DEFAULT_LONG_HISTORY_PURGE_THRESHOLD = 1000L;
+
     private final AtomicBoolean interruptionHandler;
     private boolean reindexDefaultWorkspace = Boolean.FALSE;
     private boolean checkIntegrity = Boolean.FALSE;
@@ -33,9 +40,9 @@ public class CleanerContext {
     private List<String> skippedPaths = null;
     private boolean restartFromLastPosition = Boolean.FALSE;
     private boolean runAsynchronously = Boolean.TRUE;
-    private long thresholdLongHistoryPurgeStrategy = 1000;
+    private long thresholdLongHistoryPurgeStrategy = DEFAULT_LONG_HISTORY_PURGE_THRESHOLD;
     private boolean useVersioningApi = Boolean.FALSE;
-    private long sessionRefreshInterval = 100L;
+    private long sessionRefreshInterval = DEFAULT_SESSION_REFRESH_INTERVAL;
 
     private Connection dbConnection;
     private JCRSessionWrapper editSession;
@@ -181,9 +188,12 @@ public class CleanerContext {
     }
 
     public void refreshSessions() throws RepositoryException {
+        // Guard against a misconfigured interval: a non-positive value would otherwise raise
+        // ArithmeticException (modulo by zero) and abort the scan mid-batch.
+        if (sessionRefreshInterval <= 0) return;
         if (processedVersionHistoriesCount % sessionRefreshInterval != 0) return;
-        editSession.refresh(false);
-        liveSession.refresh(false);
+        if (editSession != null) editSession.refresh(false);
+        if (liveSession != null) liveSession.refresh(false);
     }
 
     /*

--- a/src/test/java/org/jahia/community/versionscleaner/CleanCommandPathTest.java
+++ b/src/test/java/org/jahia/community/versionscleaner/CleanCommandPathTest.java
@@ -1,0 +1,42 @@
+package org.jahia.community.versionscleaner;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link CleanCommand#normalizeSubtreePath} which guards the destructive scan against
+ * escaping the version-storage root via parent/self path segments.
+ */
+public class CleanCommandPathTest {
+
+    @Test
+    public void stripsLeadingSlash() {
+        assertThat(CleanCommand.normalizeSubtreePath("/a/b/c")).isEqualTo("a/b/c");
+    }
+
+    @Test
+    public void leavesRelativePathUnchanged() {
+        assertThat(CleanCommand.normalizeSubtreePath("a/b/c")).isEqualTo("a/b/c");
+    }
+
+    @Test
+    public void rejectsParentTraversalSegment() {
+        assertThatThrownBy(() -> CleanCommand.normalizeSubtreePath("a/../b"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("parent or self");
+    }
+
+    @Test
+    public void rejectsLeadingParentTraversalSegment() {
+        assertThatThrownBy(() -> CleanCommand.normalizeSubtreePath("/../etc"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void rejectsSelfSegment() {
+        assertThatThrownBy(() -> CleanCommand.normalizeSubtreePath("a/./b"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/org/jahia/community/versionscleaner/CleanCommandRetentionTest.java
+++ b/src/test/java/org/jahia/community/versionscleaner/CleanCommandRetentionTest.java
@@ -1,0 +1,90 @@
+package org.jahia.community.versionscleaner;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Focused tests for the retention/bounds logic of {@link CleanCommand#retainNewestVersions}.
+ *
+ * The list is ordered oldest-first (root already excluded). After the call, the list must contain
+ * only the versions that are still candidates for deletion (i.e. the oldest ones), with the newest
+ * {@code nbVersionsToKeep} entries removed from the candidate list.
+ */
+public class CleanCommandRetentionTest {
+
+    private static List<String> versions(String... names) {
+        return new ArrayList<>(Arrays.asList(names));
+    }
+
+    @Test
+    public void keepsNewestEntriesAndLeavesOldestAsDeletionCandidates() {
+        // Arrange
+        final List<String> names = versions("v1", "v2", "v3", "v4", "v5");
+
+        // Act
+        CleanCommand.retainNewestVersions(names, 2);
+
+        // Assert - keep v4,v5 (newest two), delete v1,v2,v3
+        assertThat(names).containsExactly("v1", "v2", "v3");
+    }
+
+    @Test
+    public void keepingZeroLeavesAllAsDeletionCandidates() {
+        final List<String> names = versions("v1", "v2", "v3");
+
+        CleanCommand.retainNewestVersions(names, 0);
+
+        assertThat(names).containsExactly("v1", "v2", "v3");
+    }
+
+    @Test
+    public void keepingMoreThanAvailableDeletesNothing() {
+        final List<String> names = versions("v1", "v2");
+
+        CleanCommand.retainNewestVersions(names, 5);
+
+        assertThat(names).isEmpty();
+    }
+
+    @Test
+    public void keepingExactlyAvailableDeletesNothing() {
+        final List<String> names = versions("v1", "v2", "v3");
+
+        CleanCommand.retainNewestVersions(names, 3);
+
+        assertThat(names).isEmpty();
+    }
+
+    @Test
+    public void doesNotThrowWhenKeepCountExceedsSize() {
+        final List<String> names = versions("only");
+
+        assertThatCode(() -> CleanCommand.retainNewestVersions(names, Long.MAX_VALUE))
+                .doesNotThrowAnyException();
+        assertThat(names).isEmpty();
+    }
+
+    @Test
+    public void doesNotThrowOnEmptyList() {
+        final List<String> names = versions();
+
+        assertThatCode(() -> CleanCommand.retainNewestVersions(names, 2))
+                .doesNotThrowAnyException();
+        assertThat(names).isEmpty();
+    }
+
+    @Test
+    public void keepsSingleNewestEntry() {
+        final List<String> names = versions("v1", "v2", "v3", "v4");
+
+        CleanCommand.retainNewestVersions(names, 1);
+
+        assertThat(names).containsExactly("v1", "v2", "v3");
+    }
+}

--- a/src/test/java/org/jahia/community/versionscleaner/CleanerContextTest.java
+++ b/src/test/java/org/jahia/community/versionscleaner/CleanerContextTest.java
@@ -1,0 +1,65 @@
+package org.jahia.community.versionscleaner;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for {@link CleanerContext} configuration guards and deletion counters.
+ */
+public class CleanerContextTest {
+
+    @Test
+    public void refreshSessionsDoesNotThrowWhenIntervalIsZero() {
+        final CleanerContext context = new CleanerContext().setSessionRefreshInterval(0L);
+
+        // No modulo-by-zero ArithmeticException should escape and abort the scan.
+        assertThatCode(context::refreshSessions).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void refreshSessionsDoesNotThrowWhenIntervalIsNegative() {
+        final CleanerContext context = new CleanerContext().setSessionRefreshInterval(-5L);
+
+        assertThatCode(context::refreshSessions).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void refreshSessionsToleratesNullSessions() {
+        // Default interval is 100; processedVersionHistoriesCount starts at 0, so 0 % 100 == 0
+        // and the refresh branch is reached even though no sessions were set.
+        final CleanerContext context = new CleanerContext();
+
+        assertThatCode(context::refreshSessions).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void deleteNonOrphanVersionsRequiresNonNegativeKeepCount() {
+        assertThat(new CleanerContext().setNbVersionsToKeep(-1L).deleteNonOrphanVersions()).isFalse();
+        assertThat(new CleanerContext().setNbVersionsToKeep(0L).deleteNonOrphanVersions()).isTrue();
+        assertThat(new CleanerContext().setNbVersionsToKeep(5L).deleteNonOrphanVersions()).isTrue();
+    }
+
+    @Test
+    public void scanVersionsTreeWhenEitherActionEnabled() {
+        assertThat(new CleanerContext().scanVersionsTree()).isFalse();
+        assertThat(new CleanerContext().setDeleteOrphanedVersions(true).scanVersionsTree()).isTrue();
+        assertThat(new CleanerContext().setNbVersionsToKeep(2L).scanVersionsTree()).isTrue();
+    }
+
+    @Test
+    public void trackingSeparatesOrphanAndNonOrphanCounters() {
+        final CleanerContext context = new CleanerContext();
+
+        context.trackDeletedVersions(3L, false);
+        context.trackDeletedVersions(2L, true);
+        context.trackDeletedVersionHistory(false);
+        context.trackDeletedVersionHistory(true);
+
+        assertThat(context.getDeletedVersionsCount()).isEqualTo(3L);
+        assertThat(context.getDeletedOrphanVersionsCount()).isEqualTo(2L);
+        assertThat(context.getDeletedVersionHistoriesCount()).isEqualTo(1L);
+        assertThat(context.getDeletedOrphanVersionHistoriesCount()).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
## Summary

Behavior-preserving safety hardening of the destructive JCR version-deletion paths in `versions-cleaner`. No change to *what* gets deleted on any reachable normal path — only correctness, error visibility, and bounds/config safety.

## Changes

| Ref | File | What |
|-----|------|------|
| S1 | `CleanCommand` | Extract retention trim into clamped `retainNewestVersions`; previous `subList(size - nbToKeep, size)` could go negative when the guard count diverged from the non-root list size → swallowed `IndexOutOfBoundsException`. Now clamped to `[0, size]`; normal-path deletion counts unchanged. |
| S2 | `CleanCommand` | `keepLastNVersions` broad catch now logs at `error` with version-history path context instead of silent `info`. Per-history failure still isolated so the scan continues. |
| S3 | `CleanerContext` | `refreshSessions` guards non-positive `sessionRefreshInterval` (modulo-by-zero would abort mid-batch) and null-checks sessions. |
| S4 | `CleanCommand` | Extract parent/self traversal validation into pure `normalizeSubtreePath` (unit-testable version-storage-escape guard); `getNode` behavior unchanged. |
| S5 | `CleanCommand`, `CleanerContext` | Magic numbers → named constants: `ROOT_VERSION_COUNT`, `MAX_PRINTABLE_NAME_LENGTH`, `DEFAULT_SESSION_REFRESH_INTERVAL`, `DEFAULT_LONG_HISTORY_PURGE_THRESHOLD`. |

## Tests (new — repo had 0)

- `CleanCommandRetentionTest` (7) — retention bounds: keep 0 / N / exact / over-size / empty / single.
- `CleanCommandPathTest` (5) — subtree path normalization + `../`/`.` rejection.
- `CleanerContextTest` (6) — zero/negative refresh interval, null-session tolerance, counter separation, scan/keep guards.

Adds JUnit4 / AssertJ / Mockito test-scoped deps.

## Test plan

- [x] `mvn -q clean install` → BUILD SUCCESS
- [x] 18 tests, 0 failures, 0 errors
- [ ] No functional change to deletion semantics — verify against existing Cypress correctness suite in CI

CLA: ignorable.