### PR TITLE
feat: add module-specific versionsCleanerAdmin permission for fine-grained RBAC

### DIFF
--- a/src/javascript/VersionsCleaner/register.jsx
+++ b/src/javascript/VersionsCleaner/register.jsx
@@ -7,20 +7,20 @@ export default () => {
     console.debug('%c versions-cleaner: activation in progress', 'color: #463CBA');
     registry.add('adminRoute', 'versionsCleaner', {
         targets: ['administration-server-systemHealth:999'],
-        requiredPermission: 'admin',
+        requiredPermission: 'versionsCleanerAdmin',
         label: 'versions-cleaner:label.menu_entry',
         isSelectable: false
     });
     registry.add('adminRoute', 'versionsCleanerExecution', {
         targets: ['administration-server-versionsCleaner:1'],
-        requiredPermission: 'admin',
+        requiredPermission: 'versionsCleanerAdmin',
         label: 'versions-cleaner:label.menu_execution',
         isSelectable: true,
         render: () => React.createElement(VersionsCleanerAdmin)
     });
     registry.add('adminRoute', 'versionsCleanerConfiguration', {
         targets: ['administration-server-versionsCleaner:2'],
-        requiredPermission: 'admin',
+        requiredPermission: 'versionsCleanerAdmin',
         label: 'versions-cleaner:label.menu_configuration',
         isSelectable: true,
         render: () => React.createElement(SchedulerConfig)

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <admin jcr:primaryType="jnt:permission">
+        <versionsCleanerAdmin jcr:primaryType="jnt:permission"/>
+    </admin>
+</permissions>

--- a/src/main/java/org/jahia/community/versionscleaner/graphql/VersionsCleanerMutationExtension.java
+++ b/src/main/java/org/jahia/community/versionscleaner/graphql/VersionsCleanerMutationExtension.java
@@ -38,7 +38,7 @@ public class VersionsCleanerMutationExtension {
     @GraphQLField
     @GraphQLName("versionsCleanerRun")
     @GraphQLDescription("Triggers a versions clean operation asynchronously. Returns false if a clean is already running.")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("versionsCleanerAdmin")
     @SuppressWarnings("java:S107")
     public static Boolean run(
             @GraphQLName("nbVersionsToKeep")
@@ -104,7 +104,7 @@ public class VersionsCleanerMutationExtension {
     @GraphQLField
     @GraphQLName("versionsCleanerCreateTestVersions")
     @GraphQLDescription("Test helper: creates a versionable node and checks it in the given number of times. Returns the version history UUID, or null on error.")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("versionsCleanerAdmin")
     public static String createTestVersions(
             @GraphQLName("name")
             @GraphQLDescription("Suffix appended to the test node name")
@@ -157,7 +157,7 @@ public class VersionsCleanerMutationExtension {
     @GraphQLField
     @GraphQLName("versionsCleanerDeleteTestNode")
     @GraphQLDescription("Test helper: removes the test node created by versionsCleanerCreateTestVersions.")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("versionsCleanerAdmin")
     public static Boolean deleteTestNode(
             @GraphQLName("name")
             @GraphQLDescription("Same suffix used when creating the node")
@@ -189,7 +189,7 @@ public class VersionsCleanerMutationExtension {
     @GraphQLField
     @GraphQLName("versionsCleanerSetStartupDelay")
     @GraphQLDescription("Sets a one-shot startup delay (ms) applied before the next async run. Pass 0 to clear. Intended for automated tests only.")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("versionsCleanerAdmin")
     public static Boolean setStartupDelay(
             @GraphQLName("delayMs")
             @GraphQLDescription("Delay in milliseconds (0 = clear)")
@@ -201,7 +201,7 @@ public class VersionsCleanerMutationExtension {
     @GraphQLField
     @GraphQLName("versionsCleanerSaveConfig")
     @GraphQLDescription("Saves the versions cleaner scheduled job configuration. A module restart is required for schedule changes to take effect.")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("versionsCleanerAdmin")
     public static Boolean saveConfig(
             @GraphQLName("disabled")
             @GraphQLDescription("Whether the scheduled cleanup job is disabled")

--- a/src/main/java/org/jahia/community/versionscleaner/graphql/VersionsCleanerQueryExtension.java
+++ b/src/main/java/org/jahia/community/versionscleaner/graphql/VersionsCleanerQueryExtension.java
@@ -26,7 +26,7 @@ public class VersionsCleanerQueryExtension {
     @GraphQLField
     @GraphQLName("versionsCleanerIsRunning")
     @GraphQLDescription("Returns true if a versions clean operation is currently in progress")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("versionsCleanerAdmin")
     public static Boolean isRunning() {
         return CleanCommand.isRunning();
     }
@@ -34,7 +34,7 @@ public class VersionsCleanerQueryExtension {
     @GraphQLField
     @GraphQLName("versionsCleanerVersionCount")
     @GraphQLDescription("Test helper: returns the number of non-root versions for the node at the given path. Returns -1 on error.")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("versionsCleanerAdmin")
     public static Long versionCount(@GraphQLName("nodePath") String nodePath) {
         try {
             final JCRSessionFactory sf = JCRSessionFactory.getInstance();
@@ -49,7 +49,7 @@ public class VersionsCleanerQueryExtension {
     @GraphQLField
     @GraphQLName("versionsCleanerHistoryExists")
     @GraphQLDescription("Test helper: returns true if a version history node with the given UUID still exists in the repository.")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("versionsCleanerAdmin")
     public static Boolean historyExists(@GraphQLName("historyId") String historyId) {
         try {
             JCRSessionFactory.getInstance()
@@ -64,7 +64,7 @@ public class VersionsCleanerQueryExtension {
     @GraphQLField
     @GraphQLName("versionsCleanerConfig")
     @GraphQLDescription("Returns the current versions cleaner scheduled job configuration")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("versionsCleanerAdmin")
     public static GqlVersionsCleanerConfig config() {
         final VersionsCleanerConfig config = BundleUtils.getOsgiService(VersionsCleanerConfig.class, null);
         if (config == null) {


### PR DESCRIPTION
## Summary

- Adds `src/main/import/permissions.xml` defining a new `jnt:permission` node `versionsCleanerAdmin` as a child of `admin`; packaged into `import.zip` by the Jahia Maven plugin and imported into JCR on first module deployment.
- Replaces all 9 `@GraphQLRequiresPermission("admin")` annotations across `VersionsCleanerQueryExtension` (4 methods) and `VersionsCleanerMutationExtension` (5 methods) with `@GraphQLRequiresPermission("versionsCleanerAdmin")`.
- No changes to Java logic, tests, or `pom.xml`.

**Backwards compatibility:** existing full `admin` users continue to work via JCR privilege inheritance. Non-admins can now be granted only `versionsCleanerAdmin` for fine-grained access control.

## Test plan

- [ ] Build passes: `mvn -q clean install` produces green output and `import.zip` contains `permissions.xml`
- [ ] Deploy module to Jahia and verify `versionsCleanerAdmin` node appears under `/permissions/admin/` in JCR Explorer
- [ ] Confirm a full admin user can still call all GraphQL queries/mutations
- [ ] Confirm a user granted only `versionsCleanerAdmin` (not full `admin`) can call all `versionsCleaner*` GraphQL operations
- [ ] Confirm a user with no relevant permission receives a 403 / permission denied response