### PR TITLE
test: add fine-grained permission regression tests + assignable admin role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.jahia.community</groupId>
     <artifactId>versions-cleaner</artifactId>
     <name>Versions cleaner</name>
-    <version>2.3.3-SNAPSHOT</version>
+    <version>2.3.4-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is a module to clean the versions by only keepin the last N versions of a content and also by removing the orphaned versions.</description>
 

--- a/src/main/import/roles.xml
+++ b/src/main/import/roles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<roles jcr:primaryType="jnt:roles"
+       xmlns:jcr="http://www.jcp.org/jcr/1.0"
+       xmlns:j="http://www.jahia.org/jahia/1.0"
+       xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
+
+    <versions-cleaner-administrator jcr:primaryType="jnt:role"
+                                    j:nodeTypes="rep:root"
+                                    j:roleGroup="server-role"
+                                    j:permissionNames="administrationAccess versionsCleanerAdmin"
+                                    j:privilegedAccess="true">
+        <j:translation_en jcr:primaryType="jnt:translation"
+                          jcr:language="en"
+                          jcr:title="Versions Cleaner administrator"
+                          jcr:description="Grants access to the Versions Cleaner administration without requiring full server administrator rights"/>
+    </versions-cleaner-administrator>
+</roles>

--- a/tests/cypress/e2e/05-versionsCleaner-Permissions.cy.ts
+++ b/tests/cypress/e2e/05-versionsCleaner-Permissions.cy.ts
@@ -1,0 +1,81 @@
+import {DocumentNode} from 'graphql';
+import {createUser, deleteUser, grantRoles} from '@jahia/cypress';
+
+/**
+ * Regression tests for the fine-grained `versionsCleanerAdmin` permission.
+ *
+ * These guard against the gate being silently removed or mismatched across the stack:
+ *  - Backend: every GraphQL field is annotated `@GraphQLRequiresPermission("versionsCleanerAdmin")`,
+ *    enforced as `session.getNode("/").hasPermission("versionsCleanerAdmin")` (root-node ACL check).
+ *  - Frontend: `requiredPermission: 'versionsCleanerAdmin'` in register.jsx gates the admin routes.
+ *  - RBAC content: the module ships the assignable `versions-cleaner-administrator` role
+ *    (src/main/import/roles.xml) granting only `administrationAccess` + `versionsCleanerAdmin`.
+ *
+ * The "allowed" user is granted that role and nothing else — never `admin` — so the tests prove
+ * fine-grained granularity, not merely that a full administrator can pass.
+ */
+describe('Versions Cleaner — permission enforcement', () => {
+    const ROLE_NAME = 'versions-cleaner-administrator';
+    const DENIED_USER = 'vcDeniedUser';
+    const ALLOWED_USER = 'vcAllowedUser';
+    const PASSWORD = 'VcPerm9PwdTest';
+    const ADMIN_PATH = '/jahia/administration/versionsCleanerExecution';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const isRunning: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/isRunning.graphql');
+
+    const errorsOf = (result: {graphQLErrors?: Array<{message: string}>; errors?: Array<{message: string}>}) =>
+        result.graphQLErrors ?? result.errors ?? [];
+
+    const queryIsRunningAs = (username: string) => {
+        cy.apolloClient({username, password: PASSWORD});
+        return cy.apollo({query: isRunning});
+    };
+
+    before(() => {
+        cy.login();
+        createUser(DENIED_USER, PASSWORD);
+        createUser(ALLOWED_USER, PASSWORD);
+        // The annotation resolves the permission on the JCR root node, so grant the
+        // module-shipped single-permission role on `/`.
+        grantRoles('/', [ROLE_NAME], ALLOWED_USER, 'USER');
+    });
+
+    after(() => {
+        cy.apolloClient(); // reset the current Apollo client back to root
+        cy.login();
+        deleteUser(DENIED_USER);
+        deleteUser(ALLOWED_USER);
+    });
+
+    describe('GraphQL API authorization', () => {
+        it('denies the gated query for a user without the permission', () => {
+            queryIsRunningAs(DENIED_USER).then((result: never) => {
+                const errs = errorsOf(result);
+                expect(errs, 'denial errors').to.have.length.greaterThan(0);
+                expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
+            });
+        });
+
+        it('allows the gated query for a user granted only the module permission', () => {
+            queryIsRunningAs(ALLOWED_USER).then((result: never) => {
+                expect(errorsOf(result), 'should have no errors').to.have.length(0);
+                expect((result as {data: {versionsCleanerIsRunning: boolean}}).data.versionsCleanerIsRunning).to.be.a('boolean');
+            });
+        });
+    });
+
+    describe('Admin UI authorization', () => {
+        it('hides the admin panel from a user without the permission', () => {
+            cy.login(DENIED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH, {failOnStatusCode: false});
+            cy.contains('h2', 'Versions Cleaner').should('not.exist');
+        });
+
+        it('shows the admin panel to a user granted only the module permission', () => {
+            cy.login(ALLOWED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH);
+            cy.contains('h2', 'Versions Cleaner').should('be.visible');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds end-to-end regression coverage for the `versionsCleanerAdmin` fine-grained permission and ships an **assignable server role** so the permission can be granted without full server-administrator rights.

### Changes
- **`src/main/import/roles.xml`** (new): server role `versions-cleaner-administrator` (`j:roleGroup=server-role`, `j:nodeTypes=rep:root`, `j:privilegedAccess=true`) granting only `administrationAccess versionsCleanerAdmin`. `administrationAccess` is required so the admin UI renders for the granted user.
- **`tests/cypress/e2e/05-versionsCleaner-Permissions.cy.ts`** (new): 4 tests.
  - *GraphQL API authorization* — denies the gated read-only query `versionsCleanerIsRunning` for an ungranted user (`Permission denied`); allows it (full success, boolean data) for a user granted **only** the new role.
  - *Admin UI authorization* — hides the admin panel (`h2 'Versions Cleaner'` should not exist) from an ungranted user at `/jahia/administration/versionsCleanerExecution`; shows it to a user granted only the role.
- **`pom.xml`**: bump module version `2.3.3` → `2.3.4-SNAPSHOT` so the new `roles.xml` import content is re-imported on deploy.

The allowed user is granted the role and **nothing else** (never `admin`), proving fine-grained granularity rather than that a full admin passes.

### No Java relaxation needed
There is no inner hardcoded `admin` resolver check; `@GraphQLRequiresPermission("versionsCleanerAdmin")` is the only backend gate, so the role already works end-to-end on the data path.

## Test plan
- [x] `mvn clean install` rebuilds the jar; verified `roles.xml` is embedded in `META-INF/import.zip`.
- [x] Cleared stale artifacts, then `./ci.build.sh && ./ci.startup.sh` → **45/45 specs pass** (new spec 4/4).
- [x] License health check: 0 license errors in jahia logs.