### PR TITLE
versions-cleaner: clear residual Sonar S125/S1075 false-positives

### DIFF
--- a/src/main/java/org/jahia/community/versionscleaner/CleanCommand.java
+++ b/src/main/java/org/jahia/community/versionscleaner/CleanCommand.java
@@ -64,6 +64,8 @@ public class CleanCommand implements Action {
     public static boolean isRunning() {
         return RUNNING.get();
     }
+    // S1075: this is the JCR-specification-mandated version storage path, not a configurable location.
+    @SuppressWarnings("java:S1075")
     private static final String VERSIONS_PATH = "/jcr:system/jcr:versionStorage";
     private static final String[] INVALID_REFERENCE_NODE_TYPES_TO_REMOVE = new String[]{
             JcrConstants.NT_HIERARCHYNODE,
@@ -408,8 +410,8 @@ public class CleanCommand implements Action {
      */
     static void retainNewestVersions(List<String> versionNames, long nbVersionsToKeep) {
         final int size = versionNames.size();
-        // nbVersionsToKeep is bounded by the number of versions ever created for a node, so it fits an int;
-        // clamp anyway to stay safe against pathological/overflowing configuration values.
+        // The retain count never exceeds the number of versions for a node and so fits within an int range.
+        // Clamp it anyway to stay safe against pathological or overflowing configuration values.
         final int nbToKeep = (int) Math.min(nbVersionsToKeep, size);
         final int fromIndex = Math.max(0, size - nbToKeep);
         if (fromIndex >= size) return;


### PR DESCRIPTION
## Summary

Blind review of `versions-cleaner`. The module is well-hardened (the prior loop added bounds-clamping, integrity checks, and the test-helper GraphQL API). Two residual SonarQube issues remained on `CleanCommand`, both false positives, resolved cleanly:

- **S1075 (MINOR)** — `VERSIONS_PATH = "/jcr:system/jcr:versionStorage"` flagged as a "URI to parameterize". This is the **JCR-specification-mandated** version-storage path — it is fixed, not configurable. Suppressed with a justifying comment.
- **S125 (MAJOR)** — a prose comment in `retainNewestVersions` was misdetected as commented-out code (it ended with `…fits an int;` — a trailing semicolon + bare identifier tripped the heuristic). Reworded to plain prose; no logic change.

## Test plan
- [x] `mvn clean install sonar:sonar` — BUILD SUCCESS, 18 Java tests pass
- [x] SonarQube quality gate **OK**, **0 open issues** (was 2)
- [ ] No behavior change (one suppression annotation + one comment reword). Local Cypress not run this session (EE license inaccessible in this environment; no GitHub Cypress workflow on this repo) — not relevant to these changes.