### PR TITLE
fix(deps): durable transitive-dep pins via resolutions + repair dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,35 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot configuration
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Note: security updates (triggered by vulnerability alerts) run regardless of
+# this file. These entries enable scheduled *version* updates and let Dependabot
+# open lockfile-only PRs for each manifest/lockfile pair in this repo.
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Front-end module (Yarn Classic) at the repo root
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # Cypress end-to-end tests (Yarn Berry)
+  - package-ecosystem: "npm"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # Maven module packaging (pom.xml)
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # Keep GitHub Actions workflows up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "ip-address": "^10.1.1",
     "js-yaml": "^4.1.1",
     "normalize-package-data": "^7.0.0",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "tar": "^7.5.16"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -68,7 +68,10 @@
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "axios": "^1.16.0",
     "fast-uri": "^3.1.2",
+    "form-data@^2.2.0": "^2.5.6",
+    "form-data@^2.5.0": "^2.5.6",
     "ip-address": "^10.1.1",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "undici": "^6.27.0"
   }
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -4724,17 +4724,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^2.2.0, form-data@npm:^2.5.0":
-  version: 2.5.5
-  resolution: "form-data@npm:2.5.5"
+"form-data@npm:^2.5.6":
+  version: 2.5.6
+  resolution: "form-data@npm:2.5.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
+    hasown: "npm:^2.0.4"
     mime-types: "npm:^2.1.35"
     safe-buffer: "npm:^5.2.1"
-  checksum: 10/4b6a8d07bb67089da41048e734215f68317a8e29dd5385a972bf5c458a023313c69d3b5d6b8baafbb7f808fa9881e0e2e030ffe61e096b3ddc894c516401271d
+  checksum: 10/7b2afddf638125b6d22936a1f642e88887b279504510e3f56be6dc90bea35cb8124fe6ecc75032e92264b5ebfbd183d0992307588c782eaa88d1bed76381ad6b
   languageName: node
   linkType: hard
 
@@ -5193,6 +5193,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10/619526379cda755409d856cbf3c65b82ea342151719a0a550920cf7d6a7f58f7cf079e5a78f3acd162324fc784a3d3d6f6f61aff613b47a0163c16fbe09ea89f
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10/13823863ae48161068b4c51606a3128451c66f14545a5169d667fe9fca168dcd38c27570c7a299e32ef844b8da3d55def7fe88602f8970d4311fb543ee88001a
   languageName: node
   linkType: hard
 
@@ -8549,10 +8558,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10/a475e45da3e1d1073283bb70531666f09a432eabff2b857bd7063d469a1ee1486192ff61dc0dadbb526673ce1120fee14d66a59b6b17d1e0bd3a4d5f0a52d0a6
+"undici@npm:^6.27.0":
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10/30c18cdb235edf4dd36f8aa3ace1ffaf44060289a7d62ad44c33180d2d74a224015d25574812f62ce9c625b5beb1b0b766495b650fedf356aca11eed7ce2c816
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

Several Dependabot alerts are addressed by **lockfile-only** PRs (`tar`, `undici`, `form-data`). Because those packages are **transitive** (not declared in any `package.json`), Dependabot can only rewrite the resolved version in `yarn.lock`. Any full lockfile regeneration re-resolves them against the parents' semver ranges and **reintroduces the vulnerable versions**.

Adding them to `dependencies` would be the wrong fix (phantom direct deps you'd hand-maintain forever, and it doesn't constrain what a parent pulls in). The regeneration-proof lever is Yarn's `resolutions` — which this repo already uses for several packages.

## Changes

**Durable pins via `resolutions`:**

| Package | Where | Pin | Notes |
|---------|-------|-----|-------|
| `tar` | `package.json` | `^7.5.16` | single `^7.4.3` tree → global pin safe |
| `undici` | `tests/package.json` | `^6.27.0` | single `^6.25.0` tree → global pin safe |
| `form-data` | `tests/package.json` | `^2.5.6` **scoped** to `^2.2.0`/`^2.5.0` | 2.x vuln line only; the coexisting **safe 4.x tree is left untouched** |

**`tests/yarn.lock` regenerated** (Yarn 4, matching the Berry lockfile) and verified:
- `form-data` 2.x → `2.5.6`, `form-data` 4.x stays at `4.0.5`
- `undici` → `6.27.0`

A global `"form-data"` resolution would have dragged the 4.x consumers down to 2.x and broken them — hence the scoped keys.

**Repaired `.github/dependabot.yml`:** the previous config had `package-ecosystem: ""` (empty) and covered no manifests. Now declares `npm` (`/` and `/tests`), `maven` (`/`), and `github-actions` so scheduled version updates actually run.

## Notes for reviewer

- **Root `yarn.lock` intentionally not regenerated.** It is Yarn **Classic v1** format; only Yarn 4 was available in the authoring environment and regenerating would have corrupted it into Berry format. The `tar` resolution applies automatically on the next Yarn 1 install (the Maven `frontend-maven-plugin` runs a non-frozen `yarn install`).
- The existing lockfile-only Dependabot PRs (#15 tar, #17 form-data, #18 undici) become redundant for durability once this merges.

## Test plan

- [ ] CI green (`mvn clean install`, `yarn build`, `yarn lint`)
- [ ] Confirm root `yarn.lock` picks up `tar ^7.5.16` after the build's `yarn install`
- [ ] Re-check Dependabot alerts after merge — the four transitive alerts (tar/undici/form-data) should clear