### PR TITLE
fix(deps): pin qs and uuid to patched versions (tests)

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -69,8 +69,10 @@
     "axios": "^1.16.0",
     "fast-uri": "^3.1.2",
     "ip-address": "^10.1.1",
+    "qs": "^6.15.2",
     "serialize-javascript": "^7.0.5",
     "tar": "^7.5.16",
-    "undici": "^6.27.0"
+    "undici": "^6.27.0",
+    "uuid": "^11.1.1"
   }
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -5376,20 +5376,13 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@^6.4.0:
+qs@^6.15.2, qs@^6.4.0, qs@~6.14.1:
   version "6.15.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.3.tgz#76852132a58ed5c7c0ef67e4441b9bb5d6061b3b"
   integrity sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==
   dependencies:
     es-define-property "^1.0.1"
     side-channel "^1.1.1"
-
-qs@~6.14.1:
-  version "6.14.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
-  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
-  dependencies:
-    side-channel "^1.1.0"
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -6454,10 +6447,10 @@ util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@^8.3.1, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^11.1.1, uuid@^8.3.1, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Clears the two remaining transitive dev-dep alerts, verified green (45/45).

| Alert | Package | Was | Now | Fix |
|---|---|---|---|---|
| #3 | qs (`~6.14.1` tree) | 6.14.2 | **6.15.3** | `qs: ^6.15.2` (DoS `>=6.11.1,<=6.15.1`; range couldn't reach patch) |
| #2 | uuid | 8.3.2 | **11.1.1** | `uuid: ^11.1.1` (buffer bounds check `<11.1.1`) |

Classic-compatible global resolutions matching sibling modules (privateappstore). Cypress harness (incl. mochawesome reporters that use uuid) confirmed green after the uuid 8→11 bump.