### PR TITLE
feat(deps): css-loader 7 with CSS Modules config fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-loader": "^10.0.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",
-    "css-loader": "^6.8.1",
+    "css-loader": "^7.1.4",
     "eslint": "^8.4.1",
     "eslint-plugin-jest": "^23.0.2",
     "eslint-plugin-react": "^7.32.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,7 @@ module.exports = (env, argv) => {
                         'style-loader',
                         {
                             loader: 'css-loader',
-                            options: {modules: {localIdentName: '[local]'}}
+                            options: {modules: {localIdentName: '[local]', namedExport: false, exportLocalsConvention: 'as-is'}}
                         },
                         'sass-loader'
                     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,19 +2151,19 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-loader@^6.8.1:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.11.0.tgz#33bae3bf6363d0a7c2cf9031c96c744ff54d85ba"
-  integrity sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==
+css-loader@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-7.1.4.tgz#8f6bf9f8fc8cbef7d2ef6e80acc6545eaefa90b1"
+  integrity sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==
   dependencies:
     icss-utils "^5.1.0"
-    postcss "^8.4.33"
+    postcss "^8.4.40"
     postcss-modules-extract-imports "^3.1.0"
     postcss-modules-local-by-default "^4.0.5"
     postcss-modules-scope "^3.2.0"
     postcss-modules-values "^4.0.0"
     postcss-value-parser "^4.2.0"
-    semver "^7.5.4"
+    semver "^7.6.3"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -4194,7 +4194,7 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.33:
+postcss@^8.4.40:
   version "8.5.16"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.16.tgz#1230ce0b5df354c24c0ea45f99ce5f6a88279d28"
   integrity sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==
@@ -4603,7 +4603,7 @@ semver@^7.3.2, semver@^7.3.5, semver@^7.4.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.0.tgz#ed0661039fcbcda2ce71f01fa6adbefaa77040df"
   integrity sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==
 
-semver@^7.5.4:
+semver@^7.6.3:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==


### PR DESCRIPTION
Un-holds css-loader 7 (#38) with the required migration.

## Problem
css-loader 7 changed defaults `esModule: true` + `modules.namedExport: true`. The module imports styles with a default import (`import styles from './VersionsCleaner.scss'`) and reads `styles.vc_container` — under v7 that default becomes `undefined` → `TypeError: Cannot read properties of undefined (reading 'vc_container')` → admin UI crashes → 3 Cypress specs fail.

## Fix
`webpack.config.js` css-loader options:
```js
options: {modules: {localIdentName: '[local]', namedExport: false, exportLocalsConvention: 'as-is'}}
```
- `namedExport: false` → locals map is the default export again (default import works)
- `exportLocalsConvention: 'as-is'` → preserves literal `vc_` class names (v7 would camelCase them)

No JSX changes required.

## Verification
- Build green (Java 17); `vc_container` present in the built bundle
- Full Cypress suite **45/45** (02/03/05 — previously crashing — now pass)

Supersedes Dependabot #38.